### PR TITLE
Enable conversion of complex XML to JSON

### DIFF
--- a/lib/to_xml.js
+++ b/lib/to_xml.js
@@ -43,14 +43,14 @@ function buildXml(data, builder) {
 		} else {
 			// data is an object, recurse
 			for (var key in data) {
-				if( '$' === key ) {
+				if ('$' === key) {
 				// Handle node attributes
-					for( var att in data[key] ) {
+					for (var att in data[key]) {
 						builder.att( att, data[key][att] );
 					}
-				} else if( '_' === key ) {
+				} else if ('_' === key) {
 				// This is the text content of a node
-					builder.txt( data[key] );
+					builder.txt(data[key]);
 				} else {
 				// Build a new child node
 					buildXml(data[key], builder.ele(key));
@@ -68,7 +68,6 @@ function buildXml(data, builder) {
 			data = 'null';
 		}
 
-		console.log( 'using text: ', data );
 		builder.txt(data);
 	}
 }

--- a/test/rerender_test.js
+++ b/test/rerender_test.js
@@ -426,6 +426,62 @@ exports['translates between json and xml'] = {
 				test.done();
 			});
 		});
+	},
+
+	'handles xml with attributes': function (test) {
+		test.expect(4);
+
+		var staticXml = '' +
+			'<data>' +
+				'<node1>node 1 content</node1>' +
+				'<node2 att1="att1Val">node 2 content</node2>' +
+				'<node3 att2="att2Val" att3="att3Val">' +
+					'<node4 att4="att4Val">node 4 content</node4>' +
+					'<node5></node5>' +
+					'<node6 att5="att5Val"/>' +
+				'</node3>' +
+			'</data>';
+
+		var staticJson = '' +
+			'{' +
+				'"node1":"node 1 content",' +
+				'"node2":{' +
+					'"_":"node 2 content",' +
+					'"$":{' +
+						'"att1":"att1Val"' +
+					'}' +
+				'},' +
+				'"node3":{' +
+					'"$":{' +
+						'"att2":"att2Val",' +
+						'"att3":"att3Val"' +
+					'},' +
+					'"node4":{' +
+						'"_":"node 4 content",' +
+						'"$":{' +
+							'"att4":"att4Val"' +
+						'}' +
+					'},' +
+					'"node5":"",' +
+					'"node6":{' +
+						'"$":{' +
+							'"att5":"att5Val"' +
+						'}' +
+					'}' +
+				'}' + 
+			'}';
+
+		to_json(staticXml, function (error, data) {
+			test.ifError(error);
+			var json = JSON.stringify(data);
+			test.equal(json, staticJson, 'rendered JSON should be correct');
+
+			to_xml(json, function (error, xml) {
+				test.ifError(error);
+				test.equal(xml, staticXml, 'rendered XML should be correct');
+				test.done();
+			});
+		});
 	}
 
 };


### PR DESCRIPTION
Tests passed with this change. I was able to confirm that everything translates backward/forward using the following XML as a complex test case:

<data>
  <node1>node 1 content</node1>
  <node2 att1="att1Val">node 2 content</node2>
  <node3 att2="att2Val" att3="att3Val">
    <node4 att4="att4Val">node 4 content</node4>
    <node5/>
    <node6 att5="att5Val"/>
  </node3>
</data>
