### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ our roadmap.
 In lieu of a formal style guide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality.
 Lint and test your code using [grunt](https://github.com/cowboy/grunt).
 
-##Authors
+## Authors
 
 **Adam Alexander**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
